### PR TITLE
Fix end transitions not firing

### DIFF
--- a/src/vue3-slide-up-down.js
+++ b/src/vue3-slide-up-down.js
@@ -172,7 +172,7 @@ export default {
 					...componentAttributes.value,
 					...attrs,
 					ref: container,
-					onTransitionEnd: onTransitionEnd,
+					ontransitionend: onTransitionEnd,
 				},
 				slots.default()
 			);


### PR DESCRIPTION
Hey :-)

I couldn't get the closing events to trigger and had to convert the transition key to all lowercase for it to fire off as expected.

```diff
+ ontransitionend: onTransitionEnd
- onTransitionEnd: onTransitionEnd
```

Either way, I appreciate your work! 🥳 Transitions have always been a weak spot of mine and components like these makes life so much easier.